### PR TITLE
added section number

### DIFF
--- a/docs/Basic Tutorials/(5) Combining Instructions, Stimuli, and Responses.ipynb
+++ b/docs/Basic Tutorials/(5) Combining Instructions, Stimuli, and Responses.ipynb
@@ -1,374 +1,374 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "collapsed_sections": [
-        "gdpTK0CZSwMO",
-        "hPyFNXSlFY7F",
-        "XqMqCndbWwrx",
-        "l4xeYOQYXb6x"
-      ]
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "collapsed_sections": [
+    "gdpTK0CZSwMO",
+    "hPyFNXSlFY7F",
+    "XqMqCndbWwrx",
+    "l4xeYOQYXb6x"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Combining Instructions, Stimuli, and Responses\n",
-        "Here, we combine instructions, stimuli, and response to create a complete task switching experiment. In this experiment, participants alternate between two tasks: color naming and word reading. Each trial begins with a fixation cue—a \"+\" indicates a color-naming task, while an \"x\" signals a word-reading task. The stimulus, displayed for 2000 ms, consists of a word (\"RED\" or \"GREEN\") presented in a color (red or green). For color-naming tasks, participants identify the text's color, ignoring the word; for word-reading tasks, they read the word, ignoring its color. Responses are made using keys ('f' or 'j'), with the correct key determined by the task and the stimulus properties. The experiment assesses cognitive flexibility and the ability to manage task switching, including potential interference effects from conflicting information."
-      ],
-      "metadata": {
-        "id": "YmmUtUIar_NS"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Installing sweetbean"
-      ],
-      "metadata": {
-        "id": "E5DW7Mg5swMl"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install sweetbean"
-      ],
-      "metadata": {
-        "id": "4f4nnUgPuQZ9"
-      },
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Given the following timeline, could you program a task switching experiment?"
-      ],
-      "metadata": {
-        "id": "WV_t3zqMRWsH"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "timeline = [\n",
-        "    {'color': 'red', 'word': 'RED', 'task': 'color_naming'},\n",
-        "    {'color': 'green', 'word': 'GREEN', 'task': 'color_naming'},\n",
-        "    {'color': 'green', 'word': 'RED', 'task': 'word_reading'},\n",
-        "    {'color': 'red', 'word': 'GREEN', 'task': 'word_reading'},\n",
-        "]"
-      ],
-      "metadata": {
-        "id": "Joq9bmOeSuFe"
-      },
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "First we want to declare the timeline variables"
-      ],
-      "metadata": {
-        "id": "OfkhXdnEWFVP"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Enter your code here:"
-      ],
-      "metadata": {
-        "id": "QpDewU19WNtm"
-      },
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Solution"
-      ],
-      "metadata": {
-        "id": "gdpTK0CZSwMO"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# imports\n",
-        "from sweetbean.variable import TimelineVariable\n",
-        "\n",
-        "color = TimelineVariable('color')\n",
-        "word = TimelineVariable('word')\n",
-        "task = TimelineVariable('task')"
-      ],
-      "metadata": {
-        "id": "dw9vuCGrSyk_"
-      },
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Creating the instructions"
-      ],
-      "metadata": {
-        "id": "5mQ14zy_FWkY"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Now we can generate some instructions for the experiment:"
-      ],
-      "metadata": {
-        "id": "WKqlVvs8Fp0B"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from sweetbean.stimulus import Text\n",
-        "\n",
-        "instruction_welcome = # Enter your code here\n",
-        "\n",
-        "instruction_list = [\n",
-        "    # Enter your code here\n",
-        "]\n",
-        "\n",
-        "# Create the instruction block\n",
-        "instruction_block = Block(instruction_list)"
-      ],
-      "metadata": {
-        "id": "UI5sHMpSFtXn"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Solution"
-      ],
-      "metadata": {
-        "id": "hPyFNXSlFY7F"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from sweetbean.stimulus import Text\n",
-        "from sweetbean import Block\n",
-        "\n",
-        "# Define the instruction text blocks\n",
-        "instruction_welcome = Text(\n",
-        "    text='Welcome to our task-switching experiment.<br><br> \\\n",
-        "          In this experiment, you will alternate between two tasks: color naming and word reading.<br><br> \\\n",
-        "          Press the SPACE key to continue.',\n",
-        "    choices=[' ']\n",
-        ")\n",
-        "\n",
-        "instruction_fixation = Text(\n",
-        "    text='At the beginning of each trial, you will see a fixation cue:<br><br> \\\n",
-        "          A \"+\" means you should perform the color-naming task.<br> \\\n",
-        "          An \"x\" means you should perform the word-reading task.<br><br> \\\n",
-        "          Press the SPACE key to continue.',\n",
-        "    choices=[' ']\n",
-        ")\n",
-        "\n",
-        "instruction_tasks = Text(\n",
-        "    text='For the color-naming task:<br> \\\n",
-        "          Identify the COLOR of the text, ignoring the word.<br><br> \\\n",
-        "          For the word-reading task:<br> \\\n",
-        "          Read the WORD, ignoring its color.<br><br> \\\n",
-        "          Press the SPACE key to continue.',\n",
-        "    choices=[' ']\n",
-        ")\n",
-        "\n",
-        "instruction_responses = Text(\n",
-        "    text='You will respond using the following keys:<br><br> \\\n",
-        "          For RED (color or word): press the \"f\" key.<br> \\\n",
-        "          For GREEN (color or word): press the \"j\" key.<br><br> \\\n",
-        "          The stimulus will be displayed for a short period of time, so respond quickly.<br><br> \\\n",
-        "          Press the SPACE key to continue.',\n",
-        "    choices=[' ']\n",
-        ")\n",
-        "\n",
-        "instruction_note = Text(\n",
-        "    text='Remember:<br> \\\n",
-        "          Pay attention to the fixation cue (\"+\" for color naming or \"x\" for word reading)<br><br> \\\n",
-        "          to determine the task.<br><br> \\\n",
-        "          Press the SPACE key to BEGIN the experiment.',\n",
-        "    choices=[' ']\n",
-        ")\n",
-        "\n",
-        "# Create a list of instruction stimuli for the instruction block\n",
-        "instruction_list = [\n",
-        "    instruction_welcome,\n",
-        "    instruction_fixation,\n",
-        "    instruction_tasks,\n",
-        "    instruction_responses,\n",
-        "    instruction_note\n",
-        "]\n",
-        "\n",
-        "# Create the instruction block\n",
-        "instruction_block = Block(instruction_list)\n"
-      ],
-      "metadata": {
-        "id": "UquG895cFafh"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Creating the fixation\n",
-        "The fixation cross will vary between the two tasks, maybe we can show a `+`, when the task is color_naming, and a `x` when the task is word_reading. We can do this with a function variable."
-      ],
-      "metadata": {
-        "id": "qciisI4wwtsv"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Enter your code here:"
-      ],
-      "metadata": {
-        "id": "0vfgMothWtwB"
-      },
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Solution"
-      ],
-      "metadata": {
-        "id": "XqMqCndbWwrx"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from sweetbean.variable import FunctionVariable\n",
-        "\n",
-        "# Predicates\n",
-        "def fixation_shape_fct(task):\n",
-        "    if task == 'color_naming':\n",
-        "        return '+'\n",
-        "    return 'x'\n",
-        "\n",
-        "\n",
-        "# variable\n",
-        "fixation_shape = FunctionVariable('fixation_shape', fixation_shape_fct, [task])\n"
-      ],
-      "metadata": {
-        "id": "w9fF4jACw7y5"
-      },
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Creating the correct response\n",
-        "Now let's create a correct response parameter. This one is tricky! It will depend on the color, the word and the task. So the predicate will have three input arguments. Let's say we want the participant to press f when the color is \"red\" in the color_naming task or the word is \"RED\" in the word_reading task. They should press j when the color is \"green\" in the color_naming task or the word is \"GREEN\" in the word_reading task."
-      ],
-      "metadata": {
-        "id": "jI187rtxxVRl"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Predicate for f\n",
-        "def correct_key_fct(word, color, task):\n",
-        "    if (task == 'word_reading' and word == 'RED') or \\\n",
-        "        (task == 'color_naming' and color == 'red'):\n",
-        "        return 'f'\n",
-        "    return 'j'\n",
-        "\n",
-        "\n",
-        "\n",
-        "# variable for the response\n",
-        "correct_key = FunctionVariable('correct_key', correct_key_fct, [word, color, task])"
-      ],
-      "metadata": {
-        "id": "sTdVHiJkXsam"
-      },
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Finishing the experiment\n",
-        "Now, create the stimuli, the block and the experiment"
-      ],
-      "metadata": {
-        "id": "BH_uPjk0WXiJ"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Enter your code here:"
-      ],
-      "metadata": {
-        "id": "FJp7MgndY7Vj"
-      },
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Solution\n"
-      ],
-      "metadata": {
-        "id": "l4xeYOQYXb6x"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from sweetbean.stimulus import Text\n",
-        "from sweetbean import Block, Experiment\n",
-        "\n",
-        "# Stimuli\n",
-        "fixation = Text(1000, fixation_shape)\n",
-        "so_s = Text(800)\n",
-        "stroop = Text(2000, word, color, ['f', 'j'], correct_key)\n",
-        "so_f = Text(300)\n",
-        "\n",
-        "# Block\n",
-        "train_block = Block([fixation, so_s, stroop, so_f], timeline)\n",
-        "experiment = Experiment([instruction_block, train_block])\n",
-        "\n",
-        "# Experiment\n",
-        "experiment.to_html('index.html')"
-      ],
-      "metadata": {
-        "id": "k5b_aGSKZEgM"
-      },
-      "outputs": [],
-      "execution_count": null
-    }
-  ]
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# (5) Combining Instructions, Stimuli, and Responses\n",
+    "Here, we combine instructions, stimuli, and response to create a complete task switching experiment. In this experiment, participants alternate between two tasks: color naming and word reading. Each trial begins with a fixation cue—a \"+\" indicates a color-naming task, while an \"x\" signals a word-reading task. The stimulus, displayed for 2000 ms, consists of a word (\"RED\" or \"GREEN\") presented in a color (red or green). For color-naming tasks, participants identify the text's color, ignoring the word; for word-reading tasks, they read the word, ignoring its color. Responses are made using keys ('f' or 'j'), with the correct key determined by the task and the stimulus properties. The experiment assesses cognitive flexibility and the ability to manage task switching, including potential interference effects from conflicting information."
+   ],
+   "metadata": {
+    "id": "YmmUtUIar_NS"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Installing sweetbean"
+   ],
+   "metadata": {
+    "id": "E5DW7Mg5swMl"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "!pip install sweetbean"
+   ],
+   "metadata": {
+    "id": "4f4nnUgPuQZ9"
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Given the following timeline, could you program a task switching experiment?"
+   ],
+   "metadata": {
+    "id": "WV_t3zqMRWsH"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "timeline = [\n",
+    "    {'color': 'red', 'word': 'RED', 'task': 'color_naming'},\n",
+    "    {'color': 'green', 'word': 'GREEN', 'task': 'color_naming'},\n",
+    "    {'color': 'green', 'word': 'RED', 'task': 'word_reading'},\n",
+    "    {'color': 'red', 'word': 'GREEN', 'task': 'word_reading'},\n",
+    "]"
+   ],
+   "metadata": {
+    "id": "Joq9bmOeSuFe"
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "First we want to declare the timeline variables"
+   ],
+   "metadata": {
+    "id": "OfkhXdnEWFVP"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Enter your code here:"
+   ],
+   "metadata": {
+    "id": "QpDewU19WNtm"
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Solution"
+   ],
+   "metadata": {
+    "id": "gdpTK0CZSwMO"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# imports\n",
+    "from sweetbean.variable import TimelineVariable\n",
+    "\n",
+    "color = TimelineVariable('color')\n",
+    "word = TimelineVariable('word')\n",
+    "task = TimelineVariable('task')"
+   ],
+   "metadata": {
+    "id": "dw9vuCGrSyk_"
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Creating the instructions"
+   ],
+   "metadata": {
+    "id": "5mQ14zy_FWkY"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now we can generate some instructions for the experiment:"
+   ],
+   "metadata": {
+    "id": "WKqlVvs8Fp0B"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from sweetbean.stimulus import Text\n",
+    "\n",
+    "instruction_welcome = # Enter your code here\n",
+    "\n",
+    "instruction_list = [\n",
+    "    # Enter your code here\n",
+    "]\n",
+    "\n",
+    "# Create the instruction block\n",
+    "instruction_block = Block(instruction_list)"
+   ],
+   "metadata": {
+    "id": "UI5sHMpSFtXn"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Solution"
+   ],
+   "metadata": {
+    "id": "hPyFNXSlFY7F"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from sweetbean.stimulus import Text\n",
+    "from sweetbean import Block\n",
+    "\n",
+    "# Define the instruction text blocks\n",
+    "instruction_welcome = Text(\n",
+    "    text='Welcome to our task-switching experiment.<br><br> \\\n",
+    "          In this experiment, you will alternate between two tasks: color naming and word reading.<br><br> \\\n",
+    "          Press the SPACE key to continue.',\n",
+    "    choices=[' ']\n",
+    ")\n",
+    "\n",
+    "instruction_fixation = Text(\n",
+    "    text='At the beginning of each trial, you will see a fixation cue:<br><br> \\\n",
+    "          A \"+\" means you should perform the color-naming task.<br> \\\n",
+    "          An \"x\" means you should perform the word-reading task.<br><br> \\\n",
+    "          Press the SPACE key to continue.',\n",
+    "    choices=[' ']\n",
+    ")\n",
+    "\n",
+    "instruction_tasks = Text(\n",
+    "    text='For the color-naming task:<br> \\\n",
+    "          Identify the COLOR of the text, ignoring the word.<br><br> \\\n",
+    "          For the word-reading task:<br> \\\n",
+    "          Read the WORD, ignoring its color.<br><br> \\\n",
+    "          Press the SPACE key to continue.',\n",
+    "    choices=[' ']\n",
+    ")\n",
+    "\n",
+    "instruction_responses = Text(\n",
+    "    text='You will respond using the following keys:<br><br> \\\n",
+    "          For RED (color or word): press the \"f\" key.<br> \\\n",
+    "          For GREEN (color or word): press the \"j\" key.<br><br> \\\n",
+    "          The stimulus will be displayed for a short period of time, so respond quickly.<br><br> \\\n",
+    "          Press the SPACE key to continue.',\n",
+    "    choices=[' ']\n",
+    ")\n",
+    "\n",
+    "instruction_note = Text(\n",
+    "    text='Remember:<br> \\\n",
+    "          Pay attention to the fixation cue (\"+\" for color naming or \"x\" for word reading)<br><br> \\\n",
+    "          to determine the task.<br><br> \\\n",
+    "          Press the SPACE key to BEGIN the experiment.',\n",
+    "    choices=[' ']\n",
+    ")\n",
+    "\n",
+    "# Create a list of instruction stimuli for the instruction block\n",
+    "instruction_list = [\n",
+    "    instruction_welcome,\n",
+    "    instruction_fixation,\n",
+    "    instruction_tasks,\n",
+    "    instruction_responses,\n",
+    "    instruction_note\n",
+    "]\n",
+    "\n",
+    "# Create the instruction block\n",
+    "instruction_block = Block(instruction_list)\n"
+   ],
+   "metadata": {
+    "id": "UquG895cFafh"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Creating the fixation\n",
+    "The fixation cross will vary between the two tasks, maybe we can show a `+`, when the task is color_naming, and a `x` when the task is word_reading. We can do this with a function variable."
+   ],
+   "metadata": {
+    "id": "qciisI4wwtsv"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Enter your code here:"
+   ],
+   "metadata": {
+    "id": "0vfgMothWtwB"
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Solution"
+   ],
+   "metadata": {
+    "id": "XqMqCndbWwrx"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from sweetbean.variable import FunctionVariable\n",
+    "\n",
+    "# Predicates\n",
+    "def fixation_shape_fct(task):\n",
+    "    if task == 'color_naming':\n",
+    "        return '+'\n",
+    "    return 'x'\n",
+    "\n",
+    "\n",
+    "# variable\n",
+    "fixation_shape = FunctionVariable('fixation_shape', fixation_shape_fct, [task])\n"
+   ],
+   "metadata": {
+    "id": "w9fF4jACw7y5"
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Creating the correct response\n",
+    "Now let's create a correct response parameter. This one is tricky! It will depend on the color, the word and the task. So the predicate will have three input arguments. Let's say we want the participant to press f when the color is \"red\" in the color_naming task or the word is \"RED\" in the word_reading task. They should press j when the color is \"green\" in the color_naming task or the word is \"GREEN\" in the word_reading task."
+   ],
+   "metadata": {
+    "id": "jI187rtxxVRl"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Predicate for f\n",
+    "def correct_key_fct(word, color, task):\n",
+    "    if (task == 'word_reading' and word == 'RED') or \\\n",
+    "        (task == 'color_naming' and color == 'red'):\n",
+    "        return 'f'\n",
+    "    return 'j'\n",
+    "\n",
+    "\n",
+    "\n",
+    "# variable for the response\n",
+    "correct_key = FunctionVariable('correct_key', correct_key_fct, [word, color, task])"
+   ],
+   "metadata": {
+    "id": "sTdVHiJkXsam"
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Finishing the experiment\n",
+    "Now, create the stimuli, the block and the experiment"
+   ],
+   "metadata": {
+    "id": "BH_uPjk0WXiJ"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Enter your code here:"
+   ],
+   "metadata": {
+    "id": "FJp7MgndY7Vj"
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Solution\n"
+   ],
+   "metadata": {
+    "id": "l4xeYOQYXb6x"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from sweetbean.stimulus import Text\n",
+    "from sweetbean import Block, Experiment\n",
+    "\n",
+    "# Stimuli\n",
+    "fixation = Text(1000, fixation_shape)\n",
+    "so_s = Text(800)\n",
+    "stroop = Text(2000, word, color, ['f', 'j'], correct_key)\n",
+    "so_f = Text(300)\n",
+    "\n",
+    "# Block\n",
+    "train_block = Block([fixation, so_s, stroop, so_f], timeline)\n",
+    "experiment = Experiment([instruction_block, train_block])\n",
+    "\n",
+    "# Experiment\n",
+    "experiment.to_html('index.html')"
+   ],
+   "metadata": {
+    "id": "k5b_aGSKZEgM"
+   },
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
 }


### PR DESCRIPTION
# Description

Minor naming fix. The 5th tutorial isn't numbered like the others are in the navigation menu: https://autoresearch.github.io/sweetbean/Basic%20Tutorials/%285%29%20Combining%20Instructions%2C%20Stimuli%2C%20and%20Responses/

# Type of change

*Delete as appropriate:*
- **fix**: A bug fix
- **docs**: Documentation only changes
